### PR TITLE
Where strings and groups, fixes #11

### DIFF
--- a/mssql_dataframe/core/dynamic.py
+++ b/mssql_dataframe/core/dynamic.py
@@ -95,9 +95,9 @@ def where(cursor: pyodbc.connect, where: str) -> Tuple[str, list[str]]:
     conditions = re.split(combine, where, flags=re.IGNORECASE)
     conditions = [x.strip() for x in conditions]
     # identify parentheses grouping and remove
-    group_start = [idx for idx,x in enumerate(conditions) if x.startswith('(')]
-    group_end = [idx for idx,x in enumerate(conditions) if x.endswith(')')]
-    conditions = [re.sub(r'\(|\)','',x) for x in conditions]
+    group_start = [idx for idx, x in enumerate(conditions) if x.startswith("(")]
+    group_end = [idx for idx, x in enumerate(conditions) if x.endswith(")")]
+    conditions = [re.sub(r"\(|\)", "", x) for x in conditions]
     # split on comparison operator
     conditions = [re.split(comparison, x, flags=re.IGNORECASE) for x in conditions]
     if len(conditions) == 1 and len(conditions[0]) == 1:
@@ -117,8 +117,10 @@ def where(cursor: pyodbc.connect, where: str) -> Tuple[str, list[str]]:
         for x in conditions
     ]
     # reintroduce grouping parentheses
-    statement = ['('+x if idx in group_start else x for idx,x in enumerate(statement)]
-    statement = [x+')' if idx in group_end else x for idx,x in enumerate(statement)]
+    statement = [
+        "(" + x if idx in group_start else x for idx, x in enumerate(statement)
+    ]
+    statement = [x + ")" if idx in group_end else x for idx, x in enumerate(statement)]
     # rejoin on AND/OR
     recombine = re.findall(combine, where, flags=re.IGNORECASE) + [""]
     statement = list(zip(statement, recombine))
@@ -132,7 +134,7 @@ def where(cursor: pyodbc.connect, where: str) -> Tuple[str, list[str]]:
     }
     args = [x[1][1] for x in conditions if len(x[1]) > 1]
     # remove single quotes that originate from statements such as WHERE 'ColumnA' IS NOT NULL
-    args = [re.sub(r"^'|'$","",x) for x in args]
+    args = [re.sub(r"^'|'$", "", x) for x in args]
 
     return statement, args
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ README = (pathlib.Path(__file__).parent/"README.md").read_text()
 
 setup(
     name = "mssql_dataframe",
-    version = "1.1.2",
+    version = "1.1.3",
     license='MIT',
     license_files="LICENSE",
     description="Update, Upsert, and Merge from Python dataframes to SQL Server and Azure SQL database.",

--- a/tests/test_core/test_read.py
+++ b/tests/test_core/test_read.py
@@ -122,26 +122,27 @@ def test_select_columns(sql, sample):
 
 def test_select_where(sql, sample):
 
+    # basic test
     column_names = ["ColumnB", "ColumnC", "ColumnD"]
     dataframe = sql.read.table(
         table_name,
         column_names,
-        where="ColumnB>4 AND ColumnC IS NOT NULL OR ColumnD IS NULL",
+        where="(ColumnB>4 AND ColumnC IS NOT NULL) OR ColumnD IS NULL",
     )
     query = "(ColumnB>5 and ColumnC.notnull()) or ColumnD.isnull()"
     assert all(dataframe.columns.isin(column_names))
     assert dataframe.equals(sample[dataframe.columns].query(query))
 
-    # test multi-length operators
+    # test multi-length operators and string literal
     column_names = ["ColumnB", "ColumnC", "ColumnD", "ColumnE"]
     dataframe = sql.read.table(
         table_name,
         column_names,
-        where="ColumnB>=5 AND ColumnE !=a",
+        where="ColumnB>=5 AND ColumnE !='a'",
     )
     query = "(ColumnB>=5 and ColumnE!='a')"
     assert all(dataframe.columns.isin(column_names))
-    assert dataframe.equals(sample[dataframe.columns].query(query))   
+    assert dataframe.equals(sample[dataframe.columns].query(query))
 
 
 def test_select_limit(sql, sample):


### PR DESCRIPTION
Allows for grouping using parentheses.

Strings may now be enclosed with single quotes in where clause. Previously would raise an exception. Single quote enclosure isn't required for arguments passed to execute/executemany method, but allowing them is more related to pure SQL statements.