### PR TITLE
fixes #13 read where duplicated columns

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ README = (pathlib.Path(__file__).parent/"README.md").read_text()
 
 setup(
     name = "mssql_dataframe",
-    version = "1.1.3",
+    version = "1.1.4",
     license='MIT',
     license_files="LICENSE",
     description="Update, Upsert, and Merge from Python dataframes to SQL Server and Azure SQL database.",

--- a/tests/test_core/test_dynamic.py
+++ b/tests/test_core/test_dynamic.py
@@ -80,6 +80,14 @@ def test_where(cursor):
     )
     assert where_args == ["4"]
 
+    where = "ColumnA IS NULL OR ColumnA != 'CLOSED'"
+    where_statement, where_args = dynamic.where(cursor, where)
+    assert (
+        where_statement
+        == 'WHERE [ColumnA] IS NULL OR [ColumnA] != ?'
+    )
+    assert where_args == ["CLOSED"]
+
     conditions = "no operator present"
     with pytest.raises(custom_errors.SQLInvalidSyntax):
         dynamic.where(cursor, conditions)


### PR DESCRIPTION
Changed underlying structure from a dictionary to list of lists so that duplicated columns can be included in where statement.