### PR TITLE
allow schema_name, closes #20

### DIFF
--- a/cicd_template.py
+++ b/cicd_template.py
@@ -150,8 +150,12 @@ def build_package():
 
     # build package .gz and .whl files
     _ = run_cmd(["python", "-m", "build", f"--outdir={outdir}"])
-    print(f"built source archive {glob.glob(os.path.join(outdir,'*.tar.gz'))}")
-    print(f"built distribution {glob.glob(os.path.join(outdir,'*.whl'))}")
+    print(
+        f"built source archives present in {outdir}: {glob.glob(os.path.join(outdir,'*.tar.gz'))}"
+    )
+    print(
+        f"built distributions present in {outdir}: {glob.glob(os.path.join(outdir,'*.whl'))}"
+    )
 
     # check build result
     _ = run_cmd(["twine", "check", os.path.join(outdir, "*")])

--- a/tests/test_core/test_conversion.py
+++ b/tests/test_core/test_conversion.py
@@ -107,6 +107,12 @@ def test_sample(sql, data):
         connection=sql, table_name="##test_conversion"
     )
 
+    # only schema_name.table_name can be specified
+    with pytest.raises(ValueError):
+        conversion.get_schema(
+            connection=sql, table_name="ServerName.dbo.##test_conversion"
+        )
+
     # dynamic SQL object names
     table = dynamic.escape(cursor, "##test_conversion")
     columns = dynamic.escape(cursor, data.columns)

--- a/tests/test_core/test_create.py
+++ b/tests/test_core/test_create.py
@@ -59,7 +59,7 @@ def test_table_errors(sql):
 
 def test_table_column(sql):
 
-    table_name = "##test_table_column"
+    table_name = "dbo.##test_table_column"
     columns = {"A": "VARCHAR"}
     sql.create.table(table_name, columns)
     schema, _ = conversion.get_schema(sql.connection, table_name)


### PR DESCRIPTION
Schema name can be specified on table creation with:

```python
 table_name = 'schema_name.table_name'
```